### PR TITLE
Bug 197: Make starter parse pfsgroup parameter for DH groups 22-24

### DIFF
--- a/src/starter/args.c
+++ b/src/starter/args.c
@@ -117,6 +117,9 @@ static const char *LST_pfsgroup[] = {
 	"ecp256",
 	"ecp384",
 	"ecp521",
+	"modp1024s160",
+	"modp2048s224",
+	"modp2048s256",
 	 NULL
 };
 


### PR DESCRIPTION
Works for me between two helium instances. See [PR #2](https://github.com/vyos/vyatta-cfg-vpn/pull/2) and [PR #5](https://github.com/vyos/vyatta-cfg-vpn/pull/5) on vyatta-cfg-vpn.
