### PR TITLE
Bug 241: Make starter 'route' before 'initiate' when auto=start

### DIFF
--- a/src/starter/starter.c
+++ b/src/starter/starter.c
@@ -717,10 +717,16 @@ int main (int argc, char **argv)
 
 					if (conn->startup == STARTUP_START)
 					{
+						/*
+						 * Install kernel traps (route) before initiating the
+						 * connection so that selected traffic won't go out
+						 * unencrypted before IKE negotiation is complete.
+						 */
 						if (conn->keyexchange != KEY_EXCHANGE_IKEV1)
 						{
 							if (starter_charon_pid())
 							{
+								starter_stroke_route_conn(conn);
 								starter_stroke_initiate_conn(conn);
 							}
 						}
@@ -728,6 +734,7 @@ int main (int argc, char **argv)
 						{
 							if (starter_pluto_pid())
 							{
+								starter_whack_route_conn(conn);
 								starter_whack_initiate_conn(conn);
 							}
 						}


### PR DESCRIPTION
This patch prevents protected traffic from being passed unencrypted before IKE negotiation completes when auto=start for a conn in ipsec.conf.

An SPD entry is created before IKE negotiation completes, and the other end sees IKE packets and no unencrypted traffic:

```
vyos@a:~$ sudo setkey -PD | head
192.168.3.1[any] 192.168.3.2[any] gre
        out prio high + 1073737982 ipsec
        esp/transport//require
        created: Jun 16 22:49:50 2014  lastused:
        lifetime: 0(s) validtime: 0(s)
        spid=1449 seq=1 pid=8631
        refcnt=1
(per-socket policy)
        Policy:[Invalid direciton]
        created: Jun 16 22:49:50 2014  lastused:
```

Once IKE negotiation completes successfully, the initial SPD entry is replaced with entries linked to the negotiated SAs and encrypted traffic passes properly.

```
vyos@a:~$ sudo setkey -PD | head -n 17
192.168.3.1[any] 192.168.3.2[any] gre
        out prio high + 1073740030 ipsec
        esp/transport//unique#16384
        created: Jun 16 23:02:49 2014  lastused: Jun 16 23:03:25 2014
        lifetime: 0(s) validtime: 0(s)
        spid=1793 seq=1 pid=9101
        refcnt=2
192.168.3.2[any] 192.168.3.1[any] gre
        in prio high + 1073740030 ipsec
        esp/transport//unique#16384
        created: Jun 16 23:02:49 2014  lastused: Jun 16 23:03:25 2014
        lifetime: 0(s) validtime: 0(s)
        spid=1784 seq=2 pid=9101
        refcnt=1
(per-socket policy)
        Policy:[Invalid direciton]
        created: Jun 16 23:02:49 2014  lastused:
```
